### PR TITLE
Bump Kafka version to 3.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:8u402-b06-jre-alpine
 
 WORKDIR /opt
 
-ARG kafkaversion=3.6.1
+ARG kafkaversion=3.6.2
 ARG scalaversion=2.13
 
 ENV KRAFT_CONTAINER_HOST_NAME=


### PR DESCRIPTION
Hello!

I noticed that the Dockerfile pulls Kafka 3.6.1 from the berkeley.edu Kafka mirror, but that version no longer exists there. 3.6.1 is archived so the earliest version they have now is 3.6.2.

I updated the Dockerfile to pull 3.6.2. The [changelog for 3.6.2](https://downloads.apache.org/kafka/3.6.2/RELEASE_NOTES.html) looks pretty small and I haven't noticed any issues testing with this version.